### PR TITLE
make ec2.py importable

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -187,6 +187,8 @@ class Ec2Inventory(object):
         elif not self.is_cache_valid():
             self.do_api_calls_update_cache()
 
+
+    def ec2_print(self):
         # Data to print
         if self.args.host:
             data_to_print = self.get_host_info()
@@ -1506,5 +1508,6 @@ class Ec2Inventory(object):
             return json.dumps(data)
 
 
-# Run the script
-Ec2Inventory()
+if __name__ == '__main__':
+    # Run the script
+    Ec2Inventory().ec2_print()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

contrib/inventory/ec2.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

Updated `ec2.py` script to allow other scripts to import it and then handle its data if required.

If the script is imported, no output is emitted.
To import it, use the following snippet:

```
from ec2 import Ec2Inventory

ec2 = Ec2Inventory()
```

in case one needs to import the script for further inventory handling.
